### PR TITLE
ADD: required yml for svg images

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,6 +6,8 @@ SilverStripe\Assets\File:
   app_categories:
     image:
     - svg
+  class_for_file_extension:
+    svg:  SilverStripe\Assets\Image    
 SilverStripe\Assets\Image:
   extensions:
   - SilverStripeSVGGO\Extensions\SVGExtension


### PR DESCRIPTION
Not adding this means that the SVGs are saved as files rather than images.